### PR TITLE
Refactor JS API calls

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <script src="./static/js/monaco-editor.b58ea3f.js"></script>
         <script src="./static/js/vendors~main.b58ea3f.js"></script>
         <script src="./static/js/main.b58ea3f.js"></script>
+        <script src="./static/js/utils/apiClient.js"></script>
         <script src="./static/js/camerastream.js"></script>
         <script src="./static/js/arduinoApi.js"></script>
         <script src="./static/js/igusApi.js"></script> 

--- a/static/js/arduinoApi.js
+++ b/static/js/arduinoApi.js
@@ -65,22 +65,8 @@ class ArduinoApi {
 
   // Метод для отправки команды на сервер
   async sendCommand(command) {
-    const url = `${this.baseURL}/send`;
-    const body = JSON.stringify({ command });
-
     try {
-      const response = await fetch(url, {
-        method: 'POST',
-        body: body,
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || 'Unknown error');
-      }
-
-      // Если команда успешно отправлена
+      const data = await apiClient.postJson(`${this.baseURL}/send`, { command });
       return {
         status: data.status,
         command: data.command,

--- a/static/js/igusApi.js
+++ b/static/js/igusApi.js
@@ -5,29 +5,17 @@ class IgusApi {
 
     // Получить состояние мотора
     async getState() {
-        const response = await fetch(`${this.baseUrl}/state`);
-        if (!response.ok) throw new Error(await response.text());
-        const data = await response.json(); // Вот тут твои данные
-        return data;
+        return apiClient.getJson(`${this.baseUrl}/state`);
     }
 
     // Получить данные мотора (сжатый формат)
     async getData() {
-        const response = await fetch(`${this.baseUrl}/data`);
-        if (!response.ok) throw new Error(await response.text());
-        const data = await response.json(); // Вот тут твои данные
-        return data;
+        return apiClient.getJson(`${this.baseUrl}/data`);
     }
 
     // Универсальная отправка команды
     async sendCommand(type, params = {}) {
-        const response = await fetch(`${this.baseUrl}/`+type, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(params) // <-- убираем params как обёртку!
-        });
-        if (!response.ok) throw new Error(await response.text());
-        return await response.json();
+        return apiClient.postJson(`${this.baseUrl}/` + type, params);
     }
 
     // Команда reference (homing)

--- a/static/js/robot.js
+++ b/static/js/robot.js
@@ -27,96 +27,25 @@ window.robotServer = {
   
     // Метод для отправки команды на сервер
     async sendCommand(data) {
-      const url = `${this.baseURL}/run_script`;
-      const body = JSON.stringify(data);
-  
       try {
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: body,
-        });
-  
-        const data = await response.json();
-
-        if (!response.ok) {
-          let msg = 'Unknown error';
-          let details = null;
-
-          if (typeof data.detail === 'string') {
-            msg = data.detail;
-          } else if (data.detail && typeof data.detail === 'object') {
-            msg = data.detail.message || msg;
-            details = data.detail.states;
-          } else if (data.error) {
-            msg = data.error;
-          }
-//   // В sendCommand и xarmSendCommand
-// console.log('Response:', data);
-// console.log('Details:', data.detail && data.detail.states);
-
-// // Перед showError
-// showError(msg, details);
-          showError(msg, details);
-
-          throw new Error(msg);
-        }
-
-        // Если команда успешно отправлена
+        const result = await apiClient.postJson(`${this.baseURL}/run_script`, data);
         return {
-          status: data.status,
-          result: data.result,
+          status: result.status,
+          result: result.result,
         };
       } catch (error) {
         console.error('Ошибка при отправке команды:', error);
-//   // В sendCommand и xarmSendCommand
-// console.log('Response:', data);
-// console.log('Details:', data.detail && data.detail.states);
-
-// // Перед showError
-// showError(msg, details);
-        // showError(error.message);
-
+        showError(error.message);
         return { error: error.message };
       }
     }
     // Метод для отправки команды на сервер
     async xarmSendCommand(command) {
-      const url = `${this.baseURL}/api/xarm/command`;
-      const body = JSON.stringify({ command });
-  
       try {
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: body,
-        });
-  
-        const data = await response.json();
-
-        if (!response.ok) {
-          let msg = 'Unknown error';
-
-          if (typeof data.detail === 'string') {
-            msg = data.detail;
-          } else if (data.detail && typeof data.detail === 'object') {
-            msg = data.detail.message || msg;
-          }
-
-          throw new Error(msg);
-        }
-  
-        // Если команда успешно отправлена
-        return {
-          status: data.result
-        };
+        const data = await apiClient.postJson(`${this.baseURL}/api/xarm/command`, { command });
+        return { status: data.result };
       } catch (error) {
         console.error('Ошибка при отправке команды:', error);
-        // showError(error.message);
         return { error: error.message };
       }
     }

--- a/static/js/utils/apiClient.js
+++ b/static/js/utils/apiClient.js
@@ -1,0 +1,36 @@
+(function(global) {
+    async function postJson(url, payload) {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        });
+        let data = null;
+        try {
+            data = await response.json();
+        } catch (e) {
+            throw new Error('Invalid JSON response');
+        }
+        if (!response.ok) {
+            const message = data && (data.error || data.detail || response.statusText);
+            throw new Error(message || 'Request failed');
+        }
+        return data;
+    }
+    async function getJson(url) {
+        const response = await fetch(url);
+        let data = null;
+        try {
+            data = await response.json();
+        } catch (e) {
+            throw new Error('Invalid JSON response');
+        }
+        if (!response.ok) {
+            const message = data && (data.error || data.detail || response.statusText);
+            throw new Error(message || 'Request failed');
+        }
+        return data;
+    }
+    global.apiClient = { postJson, getJson };
+})(this);
+


### PR DESCRIPTION
## Summary
- add reusable apiClient for HTTP requests
- refactor API wrappers to use new helper
- include helper script in page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852d0f67c14832da9eaf412dab70a54